### PR TITLE
use sameSite attribute when setting cookie.

### DIFF
--- a/cookies.js
+++ b/cookies.js
@@ -39,7 +39,7 @@ function createCookie(name, value, days) {
 
 	if (typeof document.cookie != 'undefined') {
         browser.runtime.sendMessage("Cookie " + name + " created with value " + value);
-		document.cookie = name + "=" + value + expires + "; path=/";
+		document.cookie = name + "=" + value + expires + "; path=/; sameSite=Lax";
 	}
 }
 


### PR DESCRIPTION
This fixes #2 creating a cookie with the attribute "sameSite" set to "Lax". This will prevent rejection of the cookie in future browsers.